### PR TITLE
Fix tests to make them compatible with non-english GPG installations

### DIFF
--- a/__tests__/e2e/main.test.ts
+++ b/__tests__/e2e/main.test.ts
@@ -221,8 +221,8 @@ describe('GitHub Action', () => {
     const gitLogOutput = gitLogForLatestCommit(gitRepo.getDirPath())
 
     expect(gitLogOutput).toEqual(
-      expect.stringContaining(
-        `gpg:                using RSA key ${signingKeyFingerprint}`
+      expect.stringMatching(
+        `gpg:.+RSA.+${signingKeyFingerprint}`
       )
     )
   })

--- a/__tests__/unit/queue.test.ts
+++ b/__tests__/unit/queue.test.ts
@@ -192,9 +192,7 @@ describe('Queue', () => {
     const output = gitLogForLatestCommit(gitRepo.getDirPath())
 
     expect(
-      output.includes(
-        `gpg:                using RSA key ${signingKeyFingerprint}`
-      )
+      RegExp(`gpg:.+RSA.+${signingKeyFingerprint}`).test(output)
     ).toBe(true)
   })
 


### PR DESCRIPTION
This will make the tests referenced in #66 compatible with non-english GPG installations.

To do so, it replaces the full expected string with a RegExp in which the words "gpg:", RSA and the fingerprint are checked.

Although we cannot assure that it creates false-positive tests (maybe considering valid a string reporting an error with the RSA key), I think it is very unlikely, but the possibility of the user having a non-english GPG installation is very high.
