### PR TITLE
Fix failing integration test on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,16 +148,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Import GPG key
-        id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: false
-          fingerprint: 'BD98B3F42545FF93EFF55F7F3F39AA1432CA6AD7'
+      - name: Setup Git config
+        run: |
+          # Import test GPG key
+          # secretlint-disable
+          {
+            echo -e "-----BEGIN PGP PRIVATE KEY BLOCK-----"
+            cat __tests__/fixtures/test-key-committer.pgp
+            echo -e "\n-----END PGP PRIVATE KEY BLOCK-----\n"
+          } | gpg --import --batch --yes -
+          # secretlint-enable
+          # Set Git config
+          git config --global user.name 'A Committer'
+          git config --global user.email 'committer@example.com'
+          git config --global user.signingkey 'BD98B3F42545FF93EFF55F7F3F39AA1432CA6AD7'
+          git config --global commit.gpgsign true
 
       - name: Install dependencies and build
         run: yarn install && yarn build && yarn package


### PR DESCRIPTION
We have a pretty annoying bug that makes fail all `test` workflows on pull request events from a forked repository.

As we still need Git Queue action to sign commits I have just fixed it by importing the GPG key we are using for testing instead of importing it from secrets. Anyway, that's the right way to do it.

We agree on removing the signing option from the Git Queue but in this case, the Git Queue is not signing commits. I'm only testing that Git Queue does not interfere with Git global signing configuration.